### PR TITLE
adds #mapping alias for #collecting

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -8,7 +8,7 @@ Enumerating extends Enumerable with "lazy" versions of various common operations
 
 * `#selecting` selects elements that pass a test block (like `Enumerable#select`)
 * `#rejecting` selects elements that fail a test block (like `Enumerable#reject`)
-* `#collecting` applies a transforming block to each element (like `Enumerable#collect`)
+* `#collecting`/`#mapping` applies a transforming block to each element (like `Enumerable#collect` and `#map`)
 * `#uniqing` discards duplicates (like `Enumerable#uniq`)
 * `#taking`, `#taking_while`, `#dropping` and `#dropping_while` also do what you expect
 
@@ -28,7 +28,7 @@ Perhaps an example would help.  Consider the following snippet:
     9^2 = 81
     10^2 = 100
     => [1, 4, 9, 16]
-    
+
 Here we use plain old `#collect` to square a bunch of numbers, and then grab the ones less than 20. We can do the same thing using `#collecting`, rather than `#collect`:
 
     >> (1..10).collecting { |x| puts "#{x}^2 = #{x*x}"; x*x }.take_while { |x| x < 20 }

--- a/lib/enumerating/filtering.rb
+++ b/lib/enumerating/filtering.rb
@@ -21,7 +21,7 @@ module Enumerating
 end
 
 module Enumerable
-  
+
   def collecting
     Enumerating::Filter.new do |output|
       each do |element|
@@ -29,7 +29,9 @@ module Enumerable
       end
     end
   end
-  
+
+  alias mapping collecting
+
   def selecting
     Enumerating::Filter.new do |output|
       each do |element|
@@ -37,7 +39,7 @@ module Enumerable
       end
     end
   end
-  
+
   def rejecting
     Enumerating::Filter.new do |output|
       each do |element|
@@ -45,7 +47,7 @@ module Enumerable
       end
     end
   end
-  
+
   def uniqing
     Enumerating::Filter.new do |output|
       seen = Set.new
@@ -63,18 +65,18 @@ module Enumerable
       end
     end
   end
-  
+
   def taking(n)
     Enumerating::Filter.new do |output|
       if n > 0
         each_with_index do |element, index|
-          output.call(element) 
+          output.call(element)
           break if index + 1 == n
         end
       end
     end
   end
-  
+
   def taking_while
     Enumerating::Filter.new do |output|
       each do |element|
@@ -83,7 +85,7 @@ module Enumerable
       end
     end
   end
-  
+
   def dropping(n)
     Enumerating::Filter.new do |output|
       each_with_index do |element, index|
@@ -92,7 +94,7 @@ module Enumerable
       end
     end
   end
-  
+
   def dropping_while
     Enumerating::Filter.new do |output|
       taking = false
@@ -102,6 +104,6 @@ module Enumerable
       end
     end
   end
-  
+
 end
 


### PR DESCRIPTION
The alias helps the API remain consistent with the regular `Enumerable` API.  I much prefer `#map` to `#collect` and I bet I'm not the only one. ;)

Thanks again for the great gem.
